### PR TITLE
Fix compilance test compilation

### DIFF
--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -474,14 +474,8 @@ private:
     /**
      * Used only for compliance testing
      */
-    lorawan_status_t mcps_request_handler(loramac_mcps_req_t *mcps_request);
-
-    /**
-     * Used only for compliance testing
-     */
     lorawan_status_t send_compliance_test_frame_to_mac();
 
-    uint8_t compliance_test_buffer[MBED_CONF_LORA_TX_MAX_SIZE];
     compliance_test_t _compliance_test;
 #endif
 };

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1995,7 +1995,7 @@ lorawan_status_t LoRaMac::mlme_request( loramac_mlme_req_t *mlmeRequest )
     return status;
 }
 
-lorawan_status_t LoRaMac::mcps_request( loramac_mcps_req_t *mcpsRequest )
+lorawan_status_t LoRaMac::test_request( loramac_compliance_test_req_t *mcpsRequest )
 {
     if (_params.mac_state != LORAMAC_IDLE) {
         return LORAWAN_STATUS_BUSY;

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -621,20 +621,20 @@ public: // Test interface
      *
      * uint8_t buffer[] = {1, 2, 3};
      *
-     * loramac_mcps_req_t request;
+     * loramac_compliance_test_req_t request;
      * request.type = MCPS_UNCONFIRMED;
      * request.fport = 1;
      * request.f_buffer = buffer;
      * request.f_buffer_size = sizeof(buffer);
      *
-     * if (mcps_request(&request) == LORAWAN_STATUS_OK) {
+     * if (test_request(&request) == LORAWAN_STATUS_OK) {
      *   // Service started successfully. Waiting for the MCPS-Confirm event
      * }
      *
      * @endcode
      *
-     * @param [in] request    The MCPS request to perform.
-     *                        Refer to \ref loramac_mcps_req_t.
+     * @param [in] request    The test request to perform.
+     *                        Refer to \ref loramac_compliance_test_req_t.
      *
      * @return  `lorawan_status_t` The status of the operation. The possible values are:
      *          \ref LORAWAN_STATUS_OK
@@ -645,7 +645,7 @@ public: // Test interface
      *          \ref LORAWAN_STATUS_LENGTH_ERROR
      *          \ref LORAWAN_STATUS_DEVICE_OFF
      */
-    lorawan_status_t mcps_request(loramac_mcps_req_t *request);
+    lorawan_status_t test_request(loramac_compliance_test_req_t *request);
 
     /**
      * \brief   LoRaMAC set tx timer.

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1744,7 +1744,7 @@ typedef struct {
 
 typedef struct {
     /*!
-     * MCPS-Request type.
+     * Compiliance test request
      */
     mcps_type_t type;
 
@@ -1786,14 +1786,15 @@ typedef struct {
       *
       * A pointer to the buffer of the frame payload.
       */
-     void *f_buffer;
-     /** Payload size
-      *
-      * The size of the frame payload.
-      */
-     uint16_t f_buffer_size;
+    uint8_t f_buffer[LORAMAC_PHY_MAXPAYLOAD];
 
-} loramac_mcps_req_t;
+    /** Payload size
+     *
+     * The size of the frame payload.
+     */
+    uint16_t f_buffer_size;
+
+} loramac_compliance_test_req_t;
 
 /**  LoRaWAN compliance tests support data
  *
@@ -1822,7 +1823,7 @@ typedef struct compliance_test {
     /** Data provided by application
      *
      */
-    uint8_t *app_data_buffer;
+    uint8_t app_data_buffer[MBED_CONF_LORA_TX_MAX_SIZE];
     /** Downlink counter
      *
      */


### PR DESCRIPTION
### Description

Fix compilation of compilance test and at the same time refactor compliance
test handler. Renamed mcps_request as test_request as it is only used for
compliance test. Also fixed a bug with null buffer in send_compliance_test_frame_to_mac.


### Pull request type

- [X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
