### PR TITLE
BLE fixes for #9210

### DIFF
--- a/features/FEATURE_BLE/ble/services/EddystoneConfigService.h
+++ b/features/FEATURE_BLE/ble/services/EddystoneConfigService.h
@@ -21,6 +21,8 @@
 
 #include "ble/BLE.h"
 #include "ble/services/EddystoneService.h"
+#include "Timer.h"
+#include "Ticker.h"
 
 #define UUID_URI_BEACON(FIRST, SECOND) {                         \
         0xee, 0x0c, FIRST, SECOND, 0x87, 0x86, 0x40, 0xba,       \
@@ -496,8 +498,8 @@ private:
 
     BLEDevice                                  &ble;
     Params_t                                   &params;
-    Ticker                                     timeSinceBootTick;
-    Timeout                                    switchFrame;
+    mbed::Ticker                               timeSinceBootTick;
+    mbed::Timeout                              switchFrame;
     // Default value that is restored on reset.
     PowerLevels_t                              &defaultAdvPowerLevels; // This goes into the advertising frames (radio power measured at 1m from device).
     PowerLevels_t                              &radioPowerLevels;      // This configures the power levels of the radio.

--- a/features/FEATURE_BLE/ble/services/EddystoneService.h
+++ b/features/FEATURE_BLE/ble/services/EddystoneService.h
@@ -21,6 +21,10 @@
 
 #include "ble/BLE.h"
 #include "CircularBuffer.h"
+#include "Timer.h"
+#include "Ticker.h"
+#include "Timeout.h"
+
 static const uint8_t BEACON_EDDYSTONE[] = {0xAA, 0xFE};
 
 //Debug is disabled by default
@@ -75,7 +79,7 @@ public:
     void (*frames[EDDYSTONE_MAX_FRAMETYPE])(uint8_t *, uint32_t);
     static const int URI_DATA_MAX = 18;
     typedef uint8_t  UriData_t[URI_DATA_MAX];
-    CircularBuffer<FrameTypes, EDDYSTONE_MAX_FRAMETYPE> overflow;
+    mbed::CircularBuffer<FrameTypes, EDDYSTONE_MAX_FRAMETYPE> overflow;
 
     // UID Frame Type subfields
     static const int UID_NAMESPACEID_SIZE = 10;
@@ -542,11 +546,11 @@ private:
     BLEDevice           &ble;
     uint16_t            advPeriodus;
     uint8_t             txPower;
-    Timer               timeSinceBootTimer;
+    mbed::Timer               timeSinceBootTimer;
     volatile uint32_t   lastBootTimerRead;
     volatile bool       advLock;
     volatile FrameTypes frameIndex;
-    Timeout             stopAdv;
+    mbed::Timeout             stopAdv;
 
 
     // URI Frame Variables
@@ -555,7 +559,7 @@ private:
     int8_t              defaultUrlPower;
     bool                urlIsSet;       // flag that enables / disable URI Frames
     float               urlAdvPeriod;   // how long the url frame will be advertised for
-    Ticker              urlTicker;
+    mbed::Ticker              urlTicker;
 
     // UID Frame Variables
     UIDNamespaceID_t    defaultUidNamespaceID;
@@ -564,7 +568,7 @@ private:
     uint16_t            uidRFU;
     bool                uidIsSet;       // flag that enables / disable UID Frames
     float               uidAdvPeriod;   // how long the uid frame will be advertised for
-    Ticker              uidTicker;
+    mbed::Ticker              uidTicker;
 
     // TLM Frame Variables
     uint8_t             TlmVersion;
@@ -574,7 +578,7 @@ private:
     volatile uint32_t   TlmTimeSinceBoot;
     bool                tlmIsSet;          // flag that enables / disables TLM frames
     float               TlmAdvPeriod;      // number of minutes between adv frames
-    Ticker              tlmTicker;
+    mbed::Ticker              tlmTicker;
 
 public:
     /*


### PR DESCRIPTION
### Description

Add missing namespaces/includes to BLE services from which `mbed.h` is removed in https://github.com/ARMmbed/mbed-os/pull/9210

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers


